### PR TITLE
Make sure the name is camelcased to the same name as the bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mautic/grapesjsbuilder-bundle",
+  "name": "mautic/grapes-js-builder-bundle",
   "description": "GrapesJS Builder with MJML support for Mautic",
   "type": "mautic-plugin",
   "version": "1.0.1",


### PR DESCRIPTION
Because the name is camelcased to GrapesjsbuilderBundle, Mautic complains when installing it as it expects GrapesJsBuilderBundle. It can be reproduced by doing:

composer require mautic/grapesjsbuilder-bundle, while adding this repository to the repositories of your composer file.