### PR TITLE
This fixes the issue where the upload is not sending the csrf causing it to fail.

### DIFF
--- a/Assets/js/builder.js
+++ b/Assets/js/builder.js
@@ -61,6 +61,7 @@ Mautic.initGrapesJS = function (object) {
         embedAsBase64: false,
         openAssetsOnDrop: 1,
         autoAdd: true,
+        headers: {'X-CSRF-Token': mauticAjaxCsrf},
     };
 
     let presetMauticConf = {


### PR DESCRIPTION
This fixes the issue where the upload is not sending the csrf causing it to fail.

Related to:   #https://github.com/Webmecanik/plugin-grapesjs-builder/issues/7