### PR TITLE
Update release-notes.yml

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -5,6 +5,5 @@ changelog:
       labels: ["enhancement", "feature"]
     - title: "🐞 Bugs"
       labels: ["bug", "regression"]
-    - title: ["Contributors"]
   contributors:
     title: "💖 Contributors"


### PR DESCRIPTION
Currently, the release notes can't be generated automatically due to this error:

```
Binding to target [Bindable@1da51a35 type = java.util.List<io.spring.githubchangeloggenerator.ApplicationProperties$Section>, value = 'none', annotations = array<Annotation>[[empty]]] failed:

    Property: changelog.sections[2].title[0]
    Value: Contributors
    Origin: URL [file:release-notes.yml]:8:15
    Reason: The elements [changelog.sections[2].title[0]] were left unbound.
```

This PR should fix that issue!