### PR TITLE
Use normal mautic image directory and allow the use of a static path

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -109,6 +109,7 @@ return [
         ],
     ],
     'parameters' => [
+        'image_path_exclude'     => ['flags', 'mejs'], // exclude certain folders from showing in the image browser
         'static_url'             => '', // optional base url for images
     ],
 ];

--- a/Config/config.php
+++ b/Config/config.php
@@ -108,4 +108,7 @@ return [
             ],
         ],
     ],
+    'parameters' => [
+        'static_url'             => '', // optional base url for images
+    ],
 ];

--- a/Helper/FileManager.php
+++ b/Helper/FileManager.php
@@ -131,7 +131,7 @@ class FileManager
     {
         $files      = [];
         $uploadDir  = $this->getUploadDir();
-       
+
         $fileSystem = new Filesystem();
 
         if (!$fileSystem->exists($uploadDir)) {
@@ -144,7 +144,7 @@ class FileManager
 
         $finder = new Finder();
         $finder->files()->in($uploadDir);
-        
+
         foreach ($finder as $file) {
             // exclude certain folders from grapesjs file manager
             if (in_array($file->getRelativePath(), $this->coreParametersHelper->get('image_path_exclude'))) {

--- a/Helper/FileManager.php
+++ b/Helper/FileManager.php
@@ -14,7 +14,7 @@ use Symfony\Component\Finder\Finder;
 
 class FileManager
 {
-    const GRAPESJS_IMAGES_DIRECTORY = 'grapesjs';
+    const GRAPESJS_IMAGES_DIRECTORY = '';
 
     /**
      * @var FileUploader
@@ -102,7 +102,10 @@ class FileManager
      */
     public function getFullUrl($fileName, $separator = '/')
     {
-        return $this->coreParametersHelper->getParameter('site_url')
+        // if a static_url (CDN) is configured use that, otherwiese use the site url
+        $url = $this->coreParametersHelper->getParameter('static_url') ?? $this->coreParametersHelper->getParameter('site_url');
+
+        return $url
             .$separator
             .$this->getGrapesJsImagesPath(false, $separator)
             .$fileName;
@@ -116,6 +119,7 @@ class FileManager
      */
     private function getGrapesJsImagesPath($fullPath = false, $separator = '/')
     {
+        // $url = rtrim($config->get('static_url'), '/').'/'.$relativeImageFolderPath;
         return $this->pathsHelper->getSystemPath('images', $fullPath)
             .$separator
             .self::GRAPESJS_IMAGES_DIRECTORY
@@ -141,7 +145,7 @@ class FileManager
 
         $finder = new Finder();
         $finder->files()->in($uploadDir);
-       
+
         foreach ($finder as $file) {
             if ($size = @getimagesize($this->getCompleteFilePath($file->getFilename()))) {
                 $files[] = [

--- a/Helper/FileManager.php
+++ b/Helper/FileManager.php
@@ -119,11 +119,9 @@ class FileManager
      */
     private function getGrapesJsImagesPath($fullPath = false, $separator = '/')
     {
-        // $url = rtrim($config->get('static_url'), '/').'/'.$relativeImageFolderPath;
         return $this->pathsHelper->getSystemPath('images', $fullPath)
             .$separator
-            .self::GRAPESJS_IMAGES_DIRECTORY
-            .$separator;
+            .self::GRAPESJS_IMAGES_DIRECTORY;
     }
 
     /**
@@ -133,6 +131,7 @@ class FileManager
     {
         $files      = [];
         $uploadDir  = $this->getUploadDir();
+       
         $fileSystem = new Filesystem();
 
         if (!$fileSystem->exists($uploadDir)) {
@@ -147,15 +146,15 @@ class FileManager
         $finder->files()->in($uploadDir);
 
         foreach ($finder as $file) {
-            if ($size = @getimagesize($this->getCompleteFilePath($file->getFilename()))) {
+            if ($size = @getimagesize($this->getCompleteFilePath($file->getRelativePathname()))) {
                 $files[] = [
-                    'src'    => $this->getFullUrl($file->getFilename()),
+                    'src'    => $this->getFullUrl($file->getRelativePathname()),
                     'width'  => $size[0],
                     'type'   => 'image',
                     'height' => $size[1],
                 ];
             } else {
-                $files[] = $this->getFullUrl($file->getFilename());
+                $files[] = $this->getFullUrl($file->getRelativePathname());
             }
         }
 

--- a/Helper/FileManager.php
+++ b/Helper/FileManager.php
@@ -103,7 +103,7 @@ class FileManager
     public function getFullUrl($fileName, $separator = '/')
     {
         // if a static_url (CDN) is configured use that, otherwiese use the site url
-        $url = $this->coreParametersHelper->getParameter('static_url') ?? $this->coreParametersHelper->getParameter('site_url');
+        $url = $this->coreParametersHelper->get('static_url') ?? $this->coreParametersHelper->get('site_url');
 
         return $url
             .$separator
@@ -144,8 +144,13 @@ class FileManager
 
         $finder = new Finder();
         $finder->files()->in($uploadDir);
-
+        
         foreach ($finder as $file) {
+            // exclude certain folders from grapesjs file manager
+            if (in_array($file->getRelativePath(), $this->coreParametersHelper->get('image_path_exclude'))) {
+                continue;
+            }
+
             if ($size = @getimagesize($this->getCompleteFilePath($file->getRelativePathname()))) {
                 $files[] = [
                     'src'    => $this->getFullUrl($file->getRelativePathname()),


### PR DESCRIPTION
Fixes the following problems and improves
- Currently grapesjs uses its own folder where it saves its images. This will make it use the default Mautic images folder
- Allows the use of folders
- Adds an optional static_url parameter that can point to a different images Url (e.g. for a cdn). Default remains site_url