### PR TITLE
Add mautic logger service

### DIFF
--- a/Controller/GrapesJsController.php
+++ b/Controller/GrapesJsController.php
@@ -35,7 +35,7 @@ class GrapesJsController extends CommonController
         if (!in_array($objectType, self::OBJECT_TYPE)) {
             throw new \Exception('Object not authorized to load custom builder', Response::HTTP_CONFLICT);
         }
-        $this->logger     = $this->get('logger');
+        $this->logger     = $this->get('monolog.logger.mautic');
 
         /** @var \Mautic\EmailBundle\Model\EmailModel|\Mautic\PageBundle\Model\PageModel $model */
         $model      = $this->getModel($objectType);


### PR DESCRIPTION
This prevent issue on current M4 
It's prevent issue:

> 500 Internal Server Error - The "logger" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead. 

Steps: 

1. Be sure you are on M4
2. You are not able to open any theme without this PR