### PR TITLE
Don't use a hardcoded version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "mautic/grapes-js-builder-bundle",
   "description": "GrapesJS Builder with MJML support for Mautic",
   "type": "mautic-plugin",
-  "version": "1.0.1",
   "keywords": ["mautic","plugin","integration"],
   "require": {
     "mautic/composer-plugin": "^1.0",


### PR DESCRIPTION
From the Packagist docs (https://packagist.org/about):

> New versions of your package are automatically fetched from tags you create in your VCS repository.
>
> The easiest way to manage versioning is to just omit the version field from the composer.json file. The version numbers will then be parsed from the tag and branch names.