### PR TITLE
For Mautic 4 we will start relying on composer/installers, so it does…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
   "type": "mautic-plugin",
   "keywords": ["mautic","plugin","integration"],
   "require": {
-    "mautic/composer-plugin": "^1.0",
     "php": "^7.2"
   },
   "require-dev": {


### PR DESCRIPTION
… not make sense to rely on a dedicated package here

For Mautic 4 we will start relying on composer/installers, so it does not make sense to rely on a dedicated package here, certainly not when the developer has the choice what to use