### PR TITLE
Declare PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "mautic-plugin",
   "keywords": ["mautic","plugin","integration"],
   "require": {
-    "php": "^7.2"
+    "php": "^7.2|^8.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^0.11.12",


### PR DESCRIPTION
Needed for https://github.com/mautic/mautic/pull/9969. We can't actually test if this plugins works against PHP 8 until we finish https://github.com/mautic/mautic/pull/9969, which is dependent on this plugin 😅 So declaring PHP 8 "support" in the `composer.json` should be fine for now!